### PR TITLE
Fix issues with determining if DHCP options should be assigned.

### DIFF
--- a/src/main/java/org/dasein/cloud/aws/network/VPC.java
+++ b/src/main/java/org/dasein/cloud/aws/network/VPC.java
@@ -589,14 +589,10 @@ public class VPC extends AbstractVLANSupport<AWSCloud> {
     private void assignDHCPOptions(VLAN vlan, String domainName, String[] dnsServers, String[] ntpServers) throws CloudException, InternalException {
         boolean differs = false;
 
-        if( vlan.getDomainName() != null ) {
-            if( domainName == null ) {
-                differs = true;
-            } else if( !domainName.equals(vlan.getDomainName()) ) {
+        if( domainName != null ) {
+            if( !domainName.equals(vlan.getDomainName()) ) {
                 differs = true;
             }
-        } else if( domainName != null ) {
-            differs = true;
         }
         if( !differs ) {
             if( vlan.getDnsServers() != null ) {
@@ -843,7 +839,7 @@ public class VPC extends AbstractVLANSupport<AWSCloud> {
                     String domain = options.getDomain();
                     String[] dns = options.getDnsServers();
                     String[] ntp = options.getNtpServers();
-                    if( domain != null || dns != null || ntp != null ) {
+                    if( domain != null || dns.length > 0 || ntp.length > 0 ) {
                         assignDHCPOptions(vlan, options.getDomain(), options.getDnsServers(), options.getNtpServers());
                     }
                     Tag[] tags = new Tag[2];


### PR DESCRIPTION
If the domainName variable in assignDHCPOptions() is null then the createDhcp method doesn't set a domain name, so the assignDHCPOptions method should not be setting differs to true if domainName is null. 

Also, the getDnsServers() and getNtpServers() methods create empty arrays if the variables are null, so the assignDHCPOptions method is always getting called because dns and ntp are never null. This is resulting in the error "org.dasein.cloud.aws.compute.EC2Exception: The request must contain the parameter configurationSet" being thrown when creating DHCP options when DHCP options were not requested.

@maksimov @drewlyall Please review.
